### PR TITLE
Rename TryParse to Extract and fix EventSource name/guid/isenabled

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             }
             childActivity.Start();
 
-            AspNetDiagnosticsEventSource.Log.ActivityStarted(childActivity.Id);
+            AspNetTelemetryCorrelaitonEventSource.Log.ActivityStarted(childActivity.Id);
             return childActivity;
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                 {
                     s_aspNetListener.StopActivity(Activity.Current, new { });
                     RemoveCurrentActivity(context);
-                    AspNetDiagnosticsEventSource.Log.ActivityStopped(activity.Id);
+                    AspNetTelemetryCorrelaitonEventSource.Log.ActivityStopped(activity.Id);
                     return true;
                 }
             }
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             {
                 s_aspNetListener.Write(AspNetActivityLostStopName, new { activity });
                 RemoveCurrentActivity(context);
-                AspNetDiagnosticsEventSource.Log.ActivityStopped(activity.Id, true);
+                AspNetTelemetryCorrelaitonEventSource.Log.ActivityStopped(activity.Id, true);
             }
         }
 
@@ -82,11 +82,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             {
                 var rootActivity = new Activity(ActivityHelper.AspNetActivityName);
 
-                rootActivity.TryParse(context.Request.Headers);
+                rootActivity.Extract(context.Request.Unvalidated.Headers);
                 if (StartAspNetActivity(rootActivity))
                 {
                     SaveCurrentActivity(context, rootActivity);
-                    AspNetDiagnosticsEventSource.Log.ActivityStarted(rootActivity.Id);
+                    AspNetTelemetryCorrelaitonEventSource.Log.ActivityStarted(rootActivity.Id);
                     return rootActivity;
                 }
             }

--- a/src/Microsoft.AspNet.TelemetryCorrelation/AspNetDiagnosticsEventSource.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/AspNetDiagnosticsEventSource.cs
@@ -5,48 +5,42 @@ namespace Microsoft.AspNet.TelemetryCorrelation
     /// <summary>
     /// ETW EventSource tracing class.
     /// </summary>
-    [EventSource(Name = "Microsoft-AspNet-Diagnostics", Guid = "e73033a3-24b2-4076-8f8a-2c0795b00746")]
-    internal sealed class AspNetDiagnosticsEventSource : EventSource
+    [EventSource(Name = "Microsoft-AspNet-Telemetry-Correlation", Guid = "ace2021e-e82c-5502-d81d-657f27612673")]
+    internal sealed class AspNetTelemetryCorrelaitonEventSource : EventSource
     {
         /// <summary>
         /// Instance of the PlatformEventSource class.
         /// </summary>
-        public static readonly AspNetDiagnosticsEventSource Log = new AspNetDiagnosticsEventSource();
+        public static readonly AspNetTelemetryCorrelaitonEventSource Log = new AspNetTelemetryCorrelaitonEventSource();
 
-        [Event(1, Message = "[TelemetryCorrelationHttpModule];Callback='{0}'", Level = EventLevel.Informational)]
+        [Event(1, Message = "Callback='{0}'", Level = EventLevel.Informational)]
         public void TelemetryCorrelationHttpModule(string callback)
         {
-            if (IsEnabled())
-            {
-                WriteEvent(1, callback);
-            }
+            WriteEvent(1, callback);
         }
 
-        [Event(3, Message = "[TelemetryCorrelationHttpModule];Activity started, Id='{0}'", Level = EventLevel.Informational)]
+        [Event(2, Message = "Activity started, Id='{0}'", Level = EventLevel.Informational)]
         public void ActivityStarted(string id)
         {
-            if (IsEnabled())
-            {
-                WriteEvent(3, id);
-            }
+            WriteEvent(2, id);
         }
 
-        [Event(4, Message = "[TelemetryCorrelationHttpModule];Activity stopped, Id='{0}', lost {1}", Level = EventLevel.Informational)]
+        [Event(3, Message = "Activity stopped, Id='{0}', lost {1}", Level = EventLevel.Informational)]
         public void ActivityStopped(string id, bool lost = false)
         {
-            if (IsEnabled())
-            {
-                WriteEvent(4, id, lost);
-            }
+            WriteEvent(3, id, lost);
         }
 
-        [Event(5, Message = "[TelemetryCorrelationHttpModule];Failed to parse header {0}, value: '{1}'", Level = EventLevel.Error)]
+        [Event(4, Message = "Failed to parse header {0}, value: '{1}'", Level = EventLevel.Error)]
         public void HeaderParsingFailure(string headerName, string headerValue)
         {
-            if (IsEnabled())
-            {
-                WriteEvent(5, headerName, headerValue);
-            }
+            WriteEvent(4, headerName, headerValue);
+        }
+
+        [Event(5, Message = "Failed to extract activity, reason {0}", Level = EventLevel.Error)]
+        public void ActvityExtractionError(string reason)
+        {
+            WriteEvent(5, reason);
         }
     }
 }

--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -31,14 +31,14 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         private void Application_BeginRequest(object sender, EventArgs e)
         {
             var context = CurrentHttpContext;
-            AspNetDiagnosticsEventSource.Log.TelemetryCorrelationHttpModule("Application_BeginRequest");
+            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_BeginRequest");
             ActivityHelper.CreateRootActivity(CurrentHttpContext);
             context.Items[BeginCalledFlag] = true;
         }
 
         private void Application_PreRequestHandlerExecute(object sender, EventArgs e)
         {
-            AspNetDiagnosticsEventSource.Log.TelemetryCorrelationHttpModule("Application_PreRequestHandlerExecute");
+            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_PreRequestHandlerExecute");
             var context = CurrentHttpContext;
             if (Activity.Current == null && context.Items[ActivityHelper.ActivityKey] is Activity)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
 
         private void Application_EndRequest(object sender, EventArgs e)
         {
-            AspNetDiagnosticsEventSource.Log.TelemetryCorrelationHttpModule("Application_EndRequest");
+            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_EndRequest");
 
             var context = CurrentHttpContext;
 

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityExtensionsTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             var activity = new Activity(TestActivityName);
             var requestHeaders = new NameValueCollection();
 
-            Assert.False(activity.TryParse(requestHeaders));
+            Assert.False(activity.Extract(requestHeaders));
 
             Assert.True(string.IsNullOrEmpty(activity.ParentId));
             Assert.Empty(activity.Baggage);
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             requestHeaders.Add(ActivityExtensions.RequestIDHeaderName, "|aba2f1e978b11111.1");
             requestHeaders.Add(ActivityExtensions.RequestIDHeaderName, "|aba2f1e978b22222.1");
 
-            Assert.True(activity.TryParse(requestHeaders));
+            Assert.True(activity.Extract(requestHeaders));
 
             Assert.Equal("|aba2f1e978b11111.1", activity.ParentId);
             Assert.Empty(activity.Baggage);
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             var requestHeaders = new NameValueCollection();
             requestHeaders.Add(ActivityExtensions.RequestIDHeaderName, "");
 
-            Assert.False(activity.TryParse(requestHeaders));
+            Assert.False(activity.Extract(requestHeaders));
 
             Assert.Null(activity.ParentId);
             Assert.Empty(activity.Baggage);
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             requestHeaders.Add(ActivityExtensions.RequestIDHeaderName, "|aba2f1e978b11111.1");
             requestHeaders.Add(ActivityExtensions.CorrelationContextHeaderName, "key1=123,key2=456,key3=789");
 
-            Assert.True(activity.TryParse(requestHeaders));
+            Assert.True(activity.Extract(requestHeaders));
 
             Assert.Equal("|aba2f1e978b11111.1", activity.ParentId);
             var baggageItems = new List<KeyValuePair<string, string>>();
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             requestHeaders.Add(ActivityExtensions.CorrelationContextHeaderName, "key4=abc,key5=def");
             requestHeaders.Add(ActivityExtensions.CorrelationContextHeaderName, "key6=xyz");
 
-            Assert.True(activity.TryParse(requestHeaders));
+            Assert.True(activity.Extract(requestHeaders));
 
             Assert.Equal("|aba2f1e978b11111.1", activity.ParentId);
             var baggageItems = new List<KeyValuePair<string, string>>();
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             requestHeaders.Add(ActivityExtensions.CorrelationContextHeaderName, "key6????xyz");
             requestHeaders.Add(ActivityExtensions.CorrelationContextHeaderName, "key7=123=456");
 
-            Assert.True(activity.TryParse(requestHeaders));
+            Assert.True(activity.Extract(requestHeaders));
 
             Assert.Equal("|aba2f1e978b11111.1", activity.ParentId);
             var baggageItems = new List<KeyValuePair<string, string>>();

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
@@ -293,6 +293,20 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     return _headers;
                 }
             }
+
+            public override UnvalidatedRequestValuesBase Unvalidated => new TestUnvalidatedRequestValues(_headers);
+        }
+
+        private class TestUnvalidatedRequestValues : UnvalidatedRequestValuesBase
+        {
+            NameValueCollection _headers = new NameValueCollection();
+
+            public TestUnvalidatedRequestValues(NameValueCollection headers)
+            {
+                this._headers = headers;
+            }
+
+            public override NameValueCollection Headers => _headers;
         }
 
         private class TestHttpResponse : HttpResponseBase


### PR DESCRIPTION
Addressing some feedback from #7 

- [x] Naming: `TryParse` should not throw. It also need to have an out parameter. Consider renaming to `Extract`

out parameter is not an options, since the method does not create Activity (and must not, it does not know which name to give to Activity)

- [x] Accessing `Request` in code `rootActivity.TryParse(context.Request.Headers);` will cause request verification and potentially will throw an exception. Consider using `Unvalidated` [property](https://msdn.microsoft.com/en-us/library/system.web.httprequestbase.unvalidated.aspx)
- [x] All callbacks implementations should catch all exceptions. Otherwise error configuring activities may crash the request processing

Activity never throws, catching exceptions from DiagSource callbacks violates general principles of DiagnositcSource and makes code unreadable. Instead listeners must never throw in the callbacks.

- [x] Do NOT check `IsEnabled()` explicitly in EventLog methods. It will be checked in the `base`'s `Write` method

- [x] Explicit specifying of a `Guid` for the event source is a bad practice. Also make sure there is no name reuse for `Microsoft-AspNet-Diagnostics`. Adding `TelemetryCorrelationHttpModule` into the name of event source will eliminate the need to prefix every string.
- [x] Use sequential event ID in `EventSource`. No need to skip `2`