### PR TITLE
Fix multiple calls to HttpContext.Items[ActivityKey] in EndRequest

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
@@ -23,13 +23,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         /// activities with the root activity of the request.
         /// </summary>
         /// <returns>If it returns an activity, it will be silently stopped with the parent activity</returns>
-        public static Activity RestoreCurrentActivity(HttpContextBase context)
+        public static Activity RestoreCurrentActivity(Activity root)
         {
-            Debug.Assert(Activity.Current == null && context.Items[ActivityKey] is Activity);
+            Debug.Assert(root != null);
 
             // workaround to restore the root activity, because we don't
             // have a way to change the Activity.Current
-            var root = (Activity)context.Items[ActivityKey];
             var childActivity = new Activity(root.OperationName);
             childActivity.SetParentId(root.Id);
             childActivity.SetStartTime(root.StartTimeUtc);

--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -40,9 +40,10 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         {
             AspNetDiagnosticsEventSource.Log.TelemetryCorrelationHttpModule("Application_PreRequestHandlerExecute");
             var context = CurrentHttpContext;
-            if (Activity.Current == null && context.Items[ActivityHelper.ActivityKey] is Activity)
+            var rootActivity = (Activity) context.Items[ActivityHelper.ActivityKey];
+            if (Activity.Current == null && rootActivity != null)
             {
-                ActivityHelper.RestoreCurrentActivity(context);
+                ActivityHelper.RestoreCurrentActivity(rootActivity);
             }
         }
 

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             ExecutionContext.SuppressFlow();
             Task.Run(() =>
             {
-                var restoredActivity = ActivityHelper.RestoreCurrentActivity(context);
+                var restoredActivity = ActivityHelper.RestoreCurrentActivity(rootActivity);
 
                 Assert.NotNull(restoredActivity);
                 Assert.True(rootActivity.Id == restoredActivity.ParentId);


### PR DESCRIPTION
Addresses some feedback from #7 
- [x] There are instances of unnecessary access to the `context.Items[ActivityHelper.ActivityKey]`. Take it once and pass as a parameter later