### PR TITLE
Fix EventSource callback names and fix messages formatting

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityExtensions.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityExtensions.cs
@@ -62,8 +62,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                             }
                             else
                             {
-                                AspNetTelemetryCorrelaitonEventSource.Log.HeaderParsingFailure(
-                                    $"{CorrelationContextHeaderName}: ", pair);
+                                AspNetTelemetryCorrelaitonEventSource.Log.HeaderParsingError(CorrelationContextHeaderName, pair);
                             }
                         }
                     }

--- a/src/Microsoft.AspNet.TelemetryCorrelation/AspNetDiagnosticsEventSource.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/AspNetDiagnosticsEventSource.cs
@@ -13,31 +13,31 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         /// </summary>
         public static readonly AspNetTelemetryCorrelaitonEventSource Log = new AspNetTelemetryCorrelaitonEventSource();
 
-        [Event(1, Message = "Callback='{0}'", Level = EventLevel.Informational)]
-        public void TelemetryCorrelationHttpModule(string callback)
+        [Event(1, Message = "Callback='{0}'", Level = EventLevel.Verbose)]
+        public void TraceCallback(string callback)
         {
             WriteEvent(1, callback);
         }
 
-        [Event(2, Message = "Activity started, Id='{0}'", Level = EventLevel.Informational)]
+        [Event(2, Message = "Activity started, Id='{0}'", Level = EventLevel.Verbose)]
         public void ActivityStarted(string id)
         {
             WriteEvent(2, id);
         }
 
-        [Event(3, Message = "Activity stopped, Id='{0}', lost {1}", Level = EventLevel.Informational)]
+        [Event(3, Message = "Activity stopped, Id='{0}', lost {1}", Level = EventLevel.Verbose)]
         public void ActivityStopped(string id, bool lost = false)
         {
             WriteEvent(3, id, lost);
         }
 
-        [Event(4, Message = "Failed to parse header {0}, value: '{1}'", Level = EventLevel.Error)]
-        public void HeaderParsingFailure(string headerName, string headerValue)
+        [Event(4, Message = "Failed to parse header '{0}', value: '{1}'", Level = EventLevel.Error)]
+        public void HeaderParsingError(string headerName, string headerValue)
         {
             WriteEvent(4, headerName, headerValue);
         }
 
-        [Event(5, Message = "Failed to extract activity, reason {0}", Level = EventLevel.Error)]
+        [Event(5, Message = "Failed to extract activity, reason '{0}'", Level = EventLevel.Error)]
         public void ActvityExtractionError(string reason)
         {
             WriteEvent(5, reason);

--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -31,14 +31,14 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         private void Application_BeginRequest(object sender, EventArgs e)
         {
             var context = CurrentHttpContext;
-            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_BeginRequest");
+            AspNetTelemetryCorrelaitonEventSource.Log.TraceCallback("Application_BeginRequest");
             ActivityHelper.CreateRootActivity(CurrentHttpContext);
             context.Items[BeginCalledFlag] = true;
         }
 
         private void Application_PreRequestHandlerExecute(object sender, EventArgs e)
         {
-            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_PreRequestHandlerExecute");
+            AspNetTelemetryCorrelaitonEventSource.Log.TraceCallback("Application_PreRequestHandlerExecute");
             var context = CurrentHttpContext;
             if (Activity.Current == null && context.Items[ActivityHelper.ActivityKey] is Activity)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
 
         private void Application_EndRequest(object sender, EventArgs e)
         {
-            AspNetTelemetryCorrelaitonEventSource.Log.TelemetryCorrelationHttpModule("Application_EndRequest");
+            AspNetTelemetryCorrelaitonEventSource.Log.TraceCallback("Application_EndRequest");
 
             var context = CurrentHttpContext;
 


### PR DESCRIPTION
See #7
- [x] `Informational` level is too high for callback notifications. Switch to `Verbose`
- [x] Names of EventSource events should have an action in the name. Not just a noun
- [x] Event Source is designed to avoid formatting in-code. Pass every string as a parameter here and let EventSource do formatting: `AspNetDiagnosticsEventSource.Log.HeaderParsingFailure($"{CorrelationContextHeaderName}: {baggageItem.Name}=", baggageItem.Value);`