### PR TITLE
Copy parent tags to the new Activity when parent is lost

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
@@ -203,6 +203,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                 childActivity.AddBaggage(item.Key, item.Value);
             }
 
+            foreach (var item in root.Tags)
+            {
+                childActivity.AddTag(item.Key, item.Value);
+            }
+
             childActivity.Start();
 
             AspNetTelemetryCorrelationEventSource.Log.ActivityRestored(childActivity.Id);

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityHelperTest.cs
@@ -54,6 +54,9 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         public async Task Can_Restore_Activity()
         {
             var rootActivity = CreateActivity();
+
+            rootActivity.AddTag("k1", "v1");
+            rootActivity.AddTag("k2", "v2");
             var context = HttpContextHelper.GetFakeHttpContext();
             await Task.Run(() =>
             {
@@ -339,6 +342,10 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             var expectedBaggage = original.Baggage.OrderBy(item => item.Value);
             var actualBaggage = restored.Baggage.OrderBy(item => item.Value);
             Assert.Equal(expectedBaggage, actualBaggage);
+
+            var expectedTags = original.Tags.OrderBy(item => item.Value);
+            var actualTags = restored.Tags.OrderBy(item => item.Value);
+            Assert.Equal(expectedTags, actualTags);
         }
 
         private Activity CreateActivity()


### PR DESCRIPTION
To enable W3C support in ApplicaitonInsights SDK (https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/945) we need to make sure tags survive when activity is lost. Until https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/issues/25 is imple,ented, we have to copy tags along with other Activity properties.

