### PR TITLE
Do not add integratedMode precondition

### DIFF
--- a/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.install.xdt
+++ b/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.install.xdt
@@ -1,7 +1,30 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
 
+  <!-- Insert global system.web node in any case -->
+  <system.web xdt:Transform="InsertIfMissing">
+  </system.web>
+
+  <!-- Search for system.web nodes:
+        - globally
+        - under location[@path='.']
+        - under location[count(@path)=0]
+        If any of above contains httpModules section - it will be reused. 
+        Otherwise it will be created under /configuration/system.web (globally)
+  -->
+  <system.web xdt:Locator="XPath(//system.web[(count(parent::location) = 0) or (count(parent::location[@path != '.' and count(@path) != 0]) = 0)])">
+    <httpModules xdt:Transform="InsertIfMissing">
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" xdt:Transform="InsertIfMissing" xdt:Locator="Match(type)"/>
+    </httpModules>
+  </system.web>
+
   <system.webServer xdt:Transform="InsertIfMissing">
+  </system.webServer>
+
+  <!-- Only one validation node is allowed to be deinfed globally or in global location tags. See explanaition above for httpModules on how it works -->
+  <system.webServer xdt:Locator="XPath(//system.webServer[(count(parent::location) = 0) or (count(parent::location[@path != '.' and count(@path) != 0]) = 0)])">
+    <validation validateIntegratedModeConfiguration="false" xdt:Transform="InsertIfMissing" />
   </system.webServer>
 
   <!-- Search for system.web nodes:

--- a/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.install.xdt
+++ b/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.install.xdt
@@ -17,9 +17,9 @@
     <modules xdt:Transform="InsertIfMissing">
       <remove name="TelemetryCorrelationHttpModule" xdt:Transform="InsertIfMissing" xdt:Locator="Match(name)"/>
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
-           preCondition="integratedMode,managedHandler" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
+           preCondition="managedHandler" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
-           preCondition="integratedMode,managedHandler" xdt:Transform="InsertIfMissing" xdt:Locator="Match(type)"/>
+           preCondition="managedHandler" xdt:Transform="InsertIfMissing" xdt:Locator="Match(type)"/>
     </modules>
   </system.webServer>
 </configuration>

--- a/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.uninstall.xdt
+++ b/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.uninstall.xdt
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <system.web xdt:Locator="XPath(//system.web[(count(parent::location) = 0) or (count(parent::location[@path != '.' and count(@path) != 0]) = 0)])">
+    <httpModules>
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
+    </httpModules>
+  </system.web>
 
   <system.webServer>
     <modules>

--- a/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.uninstall.xdt
+++ b/src/Packages/Microsoft.AspNet.TelemetryCorrelation/content/net45/web.config.uninstall.xdt
@@ -6,7 +6,7 @@
       <remove name="TelemetryCorrelationHttpModule" xdt:Transform="Remove" xdt:Locator="Match(name)"/>
       <add name="TelemetryCorrelationHttpModule" 
            type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
-           preCondition="integratedMode,managedHandler" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
+           preCondition="managedHandler" xdt:Transform="Remove" xdt:Locator="Match(type)"/>
     </modules>
   </system.webServer>
 </configuration>

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigTransformTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigTransformTest.cs
@@ -29,13 +29,16 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             const string ExpectedWebConfigContent = @"
                 <configuration>
                     <system.web>
-                        <httpModules />
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
                     </system.web>
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                     </system.webServer>
                 </configuration>";
 
@@ -48,6 +51,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModuleSomeOldName"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <add name=""TelemetryCorrelationHttpModuleSomeOldName"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
@@ -57,11 +65,17 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                     </system.webServer>
                 </configuration>";
 
@@ -74,6 +88,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""managedHandler""/> 
@@ -83,12 +102,18 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""managedHandler""/> 
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                     </system.webServer>
                 </configuration>";
 
@@ -97,11 +122,17 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         }
 
         [Fact]
-        public void VerifyUpdateWithIngegratedModeWebConfig()
+        public void VerifyUpdateWithIntegratedModeWebConfig()
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                         <modules>
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
                         </modules>
@@ -110,7 +141,13 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
@@ -127,6 +164,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
@@ -137,9 +179,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules></httpModules>
+                    </system.web>
                     <system.webServer>
-                        <modules>
-                        </modules>
+                        <modules></modules>
                     </system.webServer>
                 </configuration>";
 
@@ -152,6 +196,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
@@ -162,9 +211,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules></httpModules>
+                    </system.web>
                     <system.webServer>
-                        <modules>
-                        </modules>
+                        <modules></modules>
                     </system.webServer>
                 </configuration>";
 
@@ -177,6 +228,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <remove name=""TelemetryCorrelationHttpModule"" />
@@ -188,6 +245,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
+                        </httpModules >
+                    </system.web>
                     <system.webServer>
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
@@ -204,6 +266,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
@@ -213,12 +280,19 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                     </system.webServer>
                 </configuration>";
 
@@ -233,7 +307,13 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 
             const string ExpectedWebConfigContent = @"
                 <configuration>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                     <system.webServer>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
@@ -253,11 +333,17 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             const string ExpectedWebConfigContent = @"
                 <configuration>
                     <system.webServer>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
+                    <system.web>
+                        <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules>
+                    </system.web>
                 </configuration>";
 
             var transformedWebConfig = this.ApplyInstallTransformation(OriginalWebConfigContent, InstallConfigTransformationResourceName);

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigTransformTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigTransformTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                 <configuration>
                     <system.webServer>
                         <modules>
-                           <add name=""TelemetryCorrelationHttpModuleSomeOldName"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModuleSomeOldName"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -76,7 +76,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                 <configuration>
                     <system.webServer>
                         <modules>
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -85,9 +85,35 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                 <configuration>
                     <system.webServer>
                         <modules>
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"" preCondition=""managedHandler""/> 
                            <remove name=""TelemetryCorrelationHttpModule"" />
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
+                        </modules>
+                    </system.webServer>
+                </configuration>";
+
+            var transformedWebConfig = this.ApplyInstallTransformation(OriginalWebConfigContent, InstallConfigTransformationResourceName);
+            this.VerifyTransformation(ExpectedWebConfigContent, transformedWebConfig);
+        }
+
+        [Fact]
+        public void VerifyUpdateWithIngegratedModeWebConfig()
+        {
+            const string OriginalWebConfigContent = @"
+                <configuration>
+                    <system.webServer>
+                        <modules>
                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                        </modules>
+                    </system.webServer>
+                </configuration>";
+
+            const string ExpectedWebConfigContent = @"
+                <configuration>
+                    <system.webServer>
+                        <modules>
+                           <remove name=""TelemetryCorrelationHttpModule"" />
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -122,6 +148,31 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         }
 
         [Fact]
+        public void VerifyUninstallWithIntegratedPrecondition()
+        {
+            const string OriginalWebConfigContent = @"
+                <configuration>
+                    <system.webServer>
+                        <modules>
+                           <remove name=""TelemetryCorrelationHttpModule"" />
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                        </modules>
+                    </system.webServer>
+                </configuration>";
+
+            const string ExpectedWebConfigContent = @"
+                <configuration>
+                    <system.webServer>
+                        <modules>
+                        </modules>
+                    </system.webServer>
+                </configuration>";
+
+            var transformedWebConfig = this.ApplyUninstallTransformation(OriginalWebConfigContent, UninstallConfigTransformationResourceName);
+            this.VerifyTransformation(ExpectedWebConfigContent, transformedWebConfig);
+        }
+
+        [Fact]
         public void VerifyUninstallationWithUserModules()
         {
             const string OriginalWebConfigContent = @"
@@ -130,7 +181,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <remove name=""TelemetryCorrelationHttpModule"" />
                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -166,7 +217,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <modules runAllManagedModulesForAllRequests=""true"">
                            <add name=""UserModule"" type=""UserNamespace.WebModuleFoo""/> 
                            <remove name=""TelemetryCorrelationHttpModule"" />
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -185,7 +236,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";
@@ -204,7 +255,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <system.webServer>
                         <modules>
                            <remove name=""TelemetryCorrelationHttpModule"" />
-                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler""/> 
+                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler""/> 
                         </modules>
                     </system.webServer>
                 </configuration>";

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigWithLocaltionTagTransformTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigWithLocaltionTagTransformTest.cs
@@ -35,7 +35,13 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                           </modules>
                         </system.webServer>
                       </location>
+                      <system.web>
+                        <httpModules>
+                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                        </httpModules >
+                      </system.web>
                       <system.webServer>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                         <modules>
                           <remove name=""TelemetryCorrelationHttpModule"" />
                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
@@ -60,6 +66,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                             </system.webServer>
                         </location>
                         <location path="".""> 
+                            <system.web>
+                              <httpModules>
+                                <add name=""abc"" type=""type"" />
+                              </httpModules >
+                            </system.web>
                             <system.webServer>
                                 <modules>
                                     <add name=""abc"" type=""type""/>
@@ -78,16 +89,23 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                             </system.webServer>
                         </location>
                         <location path=""."">
+                            <system.web>
+                              <httpModules>
+                                <add name=""abc"" type=""type"" />
+                                <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                              </httpModules >
+                            </system.web>
                             <system.webServer>
                                 <modules>
                                     <add name=""abc"" type=""type"" />
                                     <remove name=""TelemetryCorrelationHttpModule"" />
                                     <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                                 </modules>
+                                <validation validateIntegratedModeConfiguration=""false"" />
                             </system.webServer>
                         </location>
-                        <system.webServer>
-                        </system.webServer>
+                        <system.web></system.web>
+                        <system.webServer></system.webServer>
                     </configuration>";
 
             var transformedWebConfig = this.ApplyInstallTransformation(OriginalWebConfigContent, InstallConfigTransformationResourceName);
@@ -100,6 +118,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             const string OriginalWebConfigContent = @"
                     <configuration> 
                         <location path="".""> 
+                            <system.web>
+                              <httpModules>
+                                <add name=""abc"" type=""type"" />
+                              </httpModules >
+                            </system.web>
                             <system.webServer>
                                 <modules>
                                     <add name=""abc"" type=""type""/>
@@ -113,16 +136,23 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             const string ExpectedWebConfigContent = @"
                     <configuration>
                       <location path=""."">
+                        <system.web>
+                          <httpModules>
+                            <add name=""abc"" type=""type"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                          </httpModules >
+                        </system.web>
                         <system.webServer>
                           <modules>
                             <add name=""abc"" type=""type"" />
                             <remove name=""TelemetryCorrelationHttpModule"" />
                             <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
+                          <validation validateIntegratedModeConfiguration=""false"" />
                         </system.webServer>
                       </location>
-                      <system.webServer>
-                      </system.webServer>
+                      <system.webServer></system.webServer>
+                      <system.web></system.web>
                     </configuration>";
 
             var transformedWebConfig = this.ApplyInstallTransformation(OriginalWebConfigContent, InstallConfigTransformationResourceName);
@@ -134,7 +164,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
         {
             const string OriginalWebConfigContent = @"
                     <configuration> 
-                        <location> 
+                        <location>
+                            <system.web>
+                              <httpModules>
+                                <add name=""abc"" type=""type"" />
+                              </httpModules >
+                            </system.web>
                             <system.webServer>
                                 <modules>
                                     <add name=""abc"" type=""type""/>
@@ -146,16 +181,23 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             const string ExpectedWebConfigContent = @"
                     <configuration>
                       <location>
+                        <system.web>
+                          <httpModules>
+                            <add name=""abc"" type=""type"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                          </httpModules>
+                        </system.web>
                         <system.webServer>
                           <modules>
                             <add name=""abc"" type=""type"" />
                             <remove name=""TelemetryCorrelationHttpModule"" />
                             <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
+                          <validation validateIntegratedModeConfiguration=""false"" />
                         </system.webServer>
                       </location>
-                      <system.webServer>
-                      </system.webServer>
+                      <system.web></system.web>
+                      <system.webServer></system.webServer>
                     </configuration>";
 
             var transformedWebConfig = this.ApplyInstallTransformation(OriginalWebConfigContent, InstallConfigTransformationResourceName);
@@ -183,8 +225,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <configuration>
                       <location path=""."">
                         <system.web> 
+                          <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                          </httpModules>
                         </system.web> 
                         <system.webServer>
+                          <validation validateIntegratedModeConfiguration=""false"" />
                           <modules>
                             <remove name=""TelemetryCorrelationHttpModule"" />
                             <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
@@ -218,14 +264,20 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <configuration>
                       <location>
                         <system.web>
+                          <httpModules>
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                          </httpModules>
                         </system.web>
                         <system.webServer>
+                          <validation validateIntegratedModeConfiguration=""false"" />
                           <modules>
                             <remove name=""TelemetryCorrelationHttpModule"" />
                             <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
                         </system.webServer>
                       </location>
+                      <system.web>
+                      </system.web>
                       <system.webServer>
                       </system.webServer>
                     </configuration>";
@@ -263,11 +315,13 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <system.web>
                         </system.web>
                         <system.webServer>
+                            <validation validateIntegratedModeConfiguration=""false"" />
                         </system.webServer>
                       </location>
                       <system.web> 
                           <httpModules> 
                               <add name=""abc"" type=""type"" /> 
+                              <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
                           </httpModules> 
                       </system.web> 
                       <system.webServer>
@@ -290,6 +344,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <configuration> 
                         <location> 
                         </location> 
+                        <system.web> 
+                          <httpModules> 
+                            <add name=""abc"" type=""type"" /> 
+                          </httpModules> 
+                        </system.web> 
                         <system.webServer>
                             <modules>
                                 <add name=""abc"" type=""type""/>
@@ -301,12 +360,19 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                     <configuration>
                       <location>
                       </location>
+                      <system.web> 
+                          <httpModules> 
+                              <add name=""abc"" type=""type"" /> 
+                              <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" />
+                          </httpModules> 
+                      </system.web> 
                       <system.webServer>
                         <modules>
                           <add name=""abc"" type=""type"" />
                           <remove name=""TelemetryCorrelationHttpModule"" />
                           <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                         </modules>
+                        <validation validateIntegratedModeConfiguration=""false"" />
                       </system.webServer>
                     </configuration>";
 

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigWithLocaltionTagTransformTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/WebConfigWithLocaltionTagTransformTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                       <system.webServer>
                         <modules>
                           <remove name=""TelemetryCorrelationHttpModule"" />
-                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                         </modules>
                       </system.webServer>
                     </configuration>";
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                                 <modules>
                                     <add name=""abc"" type=""type"" />
                                     <remove name=""TelemetryCorrelationHttpModule"" />
-                                    <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                                    <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                                 </modules>
                             </system.webServer>
                         </location>
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                           <modules>
                             <add name=""abc"" type=""type"" />
                             <remove name=""TelemetryCorrelationHttpModule"" />
-                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
                         </system.webServer>
                       </location>
@@ -150,7 +150,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                           <modules>
                             <add name=""abc"" type=""type"" />
                             <remove name=""TelemetryCorrelationHttpModule"" />
-                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
                         </system.webServer>
                       </location>
@@ -187,7 +187,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <system.webServer>
                           <modules>
                             <remove name=""TelemetryCorrelationHttpModule"" />
-                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
                         </system.webServer>
                       </location>
@@ -222,7 +222,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <system.webServer>
                           <modules>
                             <remove name=""TelemetryCorrelationHttpModule"" />
-                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                            <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                           </modules>
                         </system.webServer>
                       </location>
@@ -274,7 +274,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <modules>
                           <add name=""abc"" type=""type"" />
                           <remove name=""TelemetryCorrelationHttpModule"" />
-                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                         </modules>
                       </system.webServer>
                     </configuration>";
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
                         <modules>
                           <add name=""abc"" type=""type"" />
                           <remove name=""TelemetryCorrelationHttpModule"" />
-                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""integratedMode,managedHandler"" />
+                          <add name=""TelemetryCorrelationHttpModule"" type=""Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"" preCondition=""managedHandler"" />
                         </modules>
                       </system.webServer>
                     </configuration>";

--- a/tools/Microsoft.AspNet.TelemetryCorrelation.settings.targets
+++ b/tools/Microsoft.AspNet.TelemetryCorrelation.settings.targets
@@ -6,7 +6,7 @@
         <VersionStartYear>2018</VersionStartYear>
         <VersionMajor>1</VersionMajor>
         <VersionMinor>0</VersionMinor>
-        <VersionRelease>3</VersionRelease>
+        <VersionRelease>4</VersionRelease>
         <VersionRelease Condition="'$(BuildQuality)' != 'rtm'">$(VersionRelease)-$(BuildQuality)</VersionRelease>
     </PropertyGroup>
 


### PR DESCRIPTION
Based on https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/904 and https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/623 customers still run IIS in classic mode and cannot use TelemteryCorrelationHttpModule automatically.

Let's enable classic pipeline