### PR TITLE
update DiagnosticSource to the latest version

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -49,8 +49,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Microsoft.AspNet.TelemetryCorrelation/packages.config
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/packages.config
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net452" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net452" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net452" />
   <package id="xunit" version="2.3.1" targetFramework="net452" />

--- a/tools/Microsoft.AspNet.TelemetryCorrelation.settings.targets
+++ b/tools/Microsoft.AspNet.TelemetryCorrelation.settings.targets
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <PropertyGroup Label="NuGet package dependencies">
-        <DiagnosticSourceNuGetPackageVersion>4.4.0</DiagnosticSourceNuGetPackageVersion>
+        <DiagnosticSourceNuGetPackageVersion>4.5.0</DiagnosticSourceNuGetPackageVersion>
     </PropertyGroup>
 
     <!-- Default properties -->


### PR DESCRIPTION
DS 4.4.0 has an issue that lead to crashes in multi AppDomian apps: https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613

use 4.5.0 that fixes the issue