### PR TITLE
Validate CorrelationContext size 

### DIFF
--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityExtensionsTest.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/ActivityExtensionsTest.cs
@@ -130,5 +130,51 @@ namespace Microsoft.AspNet.TelemetryCorrelation.Tests
             var actualBaggage = activity.Baggage.OrderBy(kvp => kvp.Key);
             Assert.Equal(expectedBaggage, actualBaggage);
         }
+
+        [Theory]
+        [InlineData("key0=value0,key1=value1,key2=value2,key3=value3,key4=value4,key5=value5,key6=value6,key7=value7,key8=value8,key9=value9," +
+                    "key10=value10,key11=value11,key12=value12,key13=value13,key14=value14,key15=value15,key16=value16,key17=value17,key18=value18,key19=value19," +
+                    "key20=value20,key21=value21,key22=value22,key23=value23,key24=value24,key25=value25,key26=value26,key27=value27,key28=value28,key29=value29," +
+                    "key30=value30,key31=value31,key32=value32,key33=value33,key34=value34,key35=value35,key36=value36,key37=value37,key38=value38,key39=value39," +
+                    "key40=value40,key41=value41,key42=value42,key43=value43,key44=value44,key45=value45,key46=value46,key47=value47,key48=value48,key49=value49," +
+                    "key50=value50,key51=value51,key52=value52,key53=value53,key54=value54,key55=value55,key56=value56,key57=value57,key58=value58,key59=value59," +
+                    "key60=value60,key61=value61,key62=value62,key63=value63,key64=value64,key65=value65,key66=value66,key67=value67,key68=value68,key69=value69," +
+                    "key70=value70,key71=value71,key72=value72,key73=value73,k100=vx", 1023)] //1023 chars
+        [InlineData("key0=value0,key1=value1,key2=value2,key3=value3,key4=value4,key5=value5,key6=value6,key7=value7,key8=value8,key9=value9," +
+                    "key10=value10,key11=value11,key12=value12,key13=value13,key14=value14,key15=value15,key16=value16,key17=value17,key18=value18,key19=value19," +
+                    "key20=value20,key21=value21,key22=value22,key23=value23,key24=value24,key25=value25,key26=value26,key27=value27,key28=value28,key29=value29," +
+                    "key30=value30,key31=value31,key32=value32,key33=value33,key34=value34,key35=value35,key36=value36,key37=value37,key38=value38,key39=value39," +
+                    "key40=value40,key41=value41,key42=value42,key43=value43,key44=value44,key45=value45,key46=value46,key47=value47,key48=value48,key49=value49," +
+                    "key50=value50,key51=value51,key52=value52,key53=value53,key54=value54,key55=value55,key56=value56,key57=value57,key58=value58,key59=value59," +
+                    "key60=value60,key61=value61,key62=value62,key63=value63,key64=value64,key65=value65,key66=value66,key67=value67,key68=value68,key69=value69," +
+                    "key70=value70,key71=value71,key72=value72,key73=value73,k100=vx1", 1024)] //1024 chars
+        [InlineData("key0=value0,key1=value1,key2=value2,key3=value3,key4=value4,key5=value5,key6=value6,key7=value7,key8=value8,key9=value9," +
+                    "key10=value10,key11=value11,key12=value12,key13=value13,key14=value14,key15=value15,key16=value16,key17=value17,key18=value18,key19=value19," +
+                    "key20=value20,key21=value21,key22=value22,key23=value23,key24=value24,key25=value25,key26=value26,key27=value27,key28=value28,key29=value29," +
+                    "key30=value30,key31=value31,key32=value32,key33=value33,key34=value34,key35=value35,key36=value36,key37=value37,key38=value38,key39=value39," +
+                    "key40=value40,key41=value41,key42=value42,key43=value43,key44=value44,key45=value45,key46=value46,key47=value47,key48=value48,key49=value49," +
+                    "key50=value50,key51=value51,key52=value52,key53=value53,key54=value54,key55=value55,key56=value56,key57=value57,key58=value58,key59=value59," +
+                    "key60=value60,key61=value61,key62=value62,key63=value63,key64=value64,key65=value65,key66=value66,key67=value67,key68=value68,key69=value69," +
+                    "key70=value70,key71=value71,key72=value72,key73=value73,key74=value74", 1029)] //more than 1024 chars
+        public void Validates_Correlation_Context_Length(string correlationContext, int expectedLength)
+        {
+            var activity = new Activity(TestActivityName);
+            var requestHeaders = new NameValueCollection
+            {
+                { ActivityExtensions.RequestIDHeaderName, "|abc.1" },
+                { ActivityExtensions.CorrelationContextHeaderName, correlationContext }
+            };
+            Assert.True(activity.Extract(requestHeaders));
+
+            var baggageItems = Enumerable.Range(0, 74).Select(i => new KeyValuePair<string, string>("key" + i, "value" + i)).ToList();
+            if (expectedLength < 1024)
+            {
+                baggageItems.Add(new KeyValuePair<string, string>("k100", "vx"));
+            }
+
+            var expectedBaggage = baggageItems.OrderBy(kvp => kvp.Key);
+            var actualBaggage = activity.Baggage.OrderBy(kvp => kvp.Key);
+            Assert.Equal(expectedBaggage, actualBaggage);
+        }
     }
 }


### PR DESCRIPTION
As per Http Correlation spec, correlation context must not exceed 1024 bytes, this change validates it and does not put extra baggage pairs into the Activity after limit is exceeded.

Size of Request-Id is enforced on the Activity level and does not need validation