### PR TITLE
remove few references

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -62,11 +62,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>    
@@ -76,7 +72,7 @@
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" Condition="$(OS) == 'Windows_NT'">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" >
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
@@ -85,7 +81,7 @@
     <None Include="Microsoft.AspNet.TelemetryCorrelation.ruleset" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="web.config.install.xdt"/>
-    <Content Include="web.config.uninstall.xdt"/>
+    <Content Include="web.config.install.xdt" />
+    <Content Include="web.config.uninstall.xdt" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm surprised we need the reference to `System.Net.Http` to parse the headers for correlation context. Looks like an overkill.

Nevertheless cleaning the rest of references to make sure adding those back will be intentional,
