### PR TITLE
When Activity stack is too deep, do not write Id to error message

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
@@ -90,7 +90,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                     // in case it would ever be possible to have cycles in the Activity stack.
                     if (iteration++ == MaxActivityStackSize)
                     {
-                        AspNetTelemetryCorrelationEventSource.Log.ActivityStackIsTooDeep(currentActivity.Id, currentActivity.OperationName);
+                        // this is for internal error reporting
+                        AspNetTelemetryCorrelationEventSource.Log.ActivityStackIsTooDeepError();
+
+                        // this is for debugging
+                        AspNetTelemetryCorrelationEventSource.Log.ActivityStackIsTooDeepDetails(currentActivity.Id, currentActivity.OperationName);
                         activity.Stop();
                         return false;
                     }

--- a/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             WriteEvent(6, id, name);
         }
 
-        [Event(7, Message = "Activity stack is too deep.", Level = EventLevel.Error)]
+        [Event(7, Message = "System.Diagnostics.Activity stack is too deep. This is a code authoring error, Activity will not be stopped.", Level = EventLevel.Error)]
         public void ActivityStackIsTooDeepError()
         {
             WriteEvent(7);
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             WriteEvent(9, error);
         }
 
-        [Event(10, Message = "Activity stack is too deep, Current Id: '{0}', Name: '{1}'", Level = EventLevel.Warning)]
+        [Event(10, Message = "System.Diagnostics.Activity stack is too deep. Current Id: '{0}', Name: '{1}'", Level = EventLevel.Warning)]
         public void ActivityStackIsTooDeepDetails(string id, string name)
         {
             WriteEvent(10, id, name);

--- a/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
@@ -53,10 +53,10 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             WriteEvent(6, id, name);
         }
 
-        [Event(7, Message = "Activity stack is too deep, Current Id: '{0}', Name: '{1}'", Level = EventLevel.Error)]
-        public void ActivityStackIsTooDeep(string id, string name)
+        [Event(7, Message = "Activity stack is too deep.", Level = EventLevel.Error)]
+        public void ActivityStackIsTooDeepError()
         {
-            WriteEvent(7, id, name);
+            WriteEvent(7);
         }
 
         [Event(8, Message = "Activity restored, Id='{0}'", Level = EventLevel.Informational)]
@@ -69,6 +69,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         public void OnExecuteRequestStepInvokationError(string error)
         {
             WriteEvent(9, error);
+        }
+
+        [Event(10, Message = "Activity stack is too deep, Current Id: '{0}', Name: '{1}'", Level = EventLevel.Warning)]
+        public void ActivityStackIsTooDeepDetails(string id, string name)
+        {
+            WriteEvent(10, id, name);
         }
     }
 }


### PR DESCRIPTION
see also https://github.com/Microsoft/ApplicationInsights-dotnet/pull/954

AppInsights monitors internal SDKs errors. We need to have non-unique messages to understand the impact of the issue. 

For debugging, we keep the detailed error message.