### PR TITLE
Update the new DiagnosticSource and leverage Activity.Current setter

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview8.19405.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Microsoft.AspNet.TelemetryCorrelation.ruleset" />

--- a/src/Microsoft.AspNet.TelemetryCorrelation/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Properties/AssemblyInfo.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-[assembly: CLSCompliant(true)]
-
 #if PUBLIC_RELEASE
 [assembly: InternalsVisibleTo("Microsoft.AspNet.TelemetryCorrelation.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 #else

--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -106,32 +106,10 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             if (!context.Items.Contains(BeginCalledFlag))
             {
                 // Activity has never been started
-                var activity = ActivityHelper.CreateRootActivity(context, ParseHeaders);
-                ActivityHelper.StopAspNetActivity(activity, context.Items);
+                ActivityHelper.CreateRootActivity(context, ParseHeaders);
             }
-            else
-            {
-                var activity = (Activity)context.Items[ActivityHelper.ActivityKey];
 
-                // try to stop activity if it's in the Current stack
-                // stop all running Activities on the way
-                if (!ActivityHelper.StopAspNetActivity(activity, context.Items))
-                {
-                    // perhaps we attempted to restore the Activity before
-                    var restoredActivity = (Activity)context.Items[ActivityHelper.RestoredActivityKey];
-                    if (restoredActivity != null)
-                    {
-                        // if so, report it
-                        ActivityHelper.StopRestoredActivity(restoredActivity, context);
-                    }
-
-                    // Activity we created was lost let's report it
-                    if (activity != null)
-                    {
-                        ActivityHelper.StopLostActivity(activity, context);
-                    }
-                }
-            }
+            ActivityHelper.StopAspNetActivity(context.Items);
         }
     }
 }

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview8.19405.3" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/TestDiagnosticListener.cs
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/TestDiagnosticListener.cs
@@ -4,6 +4,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 // </copyright>
 
+using System.Diagnostics;
+using Xunit;
+
 namespace Microsoft.AspNet.TelemetryCorrelation.Tests
 {
     using System;


### PR DESCRIPTION
Fix #25 

this change leverages the new feature of DiagnosticSource: public Activity.Current setter:
- there is no need to create child Activity to restore Current
- no need to stop all children to stop one created by ASP.NET module