### PR TITLE
Set lang version to 7.3

### DIFF
--- a/tools/Common.props
+++ b/tools/Common.props
@@ -1,5 +1,9 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+ <PropertyGroup>
+   <LangVersion>7.3</LangVersion>
+ </PropertyGroup>
+
   <PropertyGroup>
     <RepositoryRoot Condition="'$(RepositoryRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.TelemetryCorrelation.sln))\</RepositoryRoot>
   </PropertyGroup>


### PR DESCRIPTION
fixes broken build: 
`##[error]test\Microsoft.AspNet.TelemetryCorrelation.Tests\ActivityExtensionsTest.cs(132,26): Error CS8107: Feature 'default literal' is not available in C# 7.0. Please use language version 7.1 or greater.
`

after #61