### PR TITLE
Call new DS callback: OnActivityImport

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/ActivityHelper.cs
@@ -34,6 +34,8 @@ namespace Microsoft.AspNet.TelemetryCorrelation
 
         private static readonly DiagnosticListener AspNetListener = new DiagnosticListener(AspNetListenerName);
 
+        private static readonly object EmptyPayload = new object();
+
         /// <summary>
         /// Stops the activity and notifies listeners about it.
         /// </summary>
@@ -52,7 +54,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             if (currentActivity != null)
             {
                 // stop Activity with Stop event
-                AspNetListener.StopActivity(currentActivity, new { });
+                AspNetListener.StopActivity(currentActivity, EmptyPayload);
                 contextItems[ActivityKey] = null;
             }
 
@@ -75,6 +77,8 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                 {
                     rootActivity.Extract(context.Request.Unvalidated.Headers);
                 }
+
+                AspNetListener.OnActivityImport(rootActivity, null);
 
                 if (StartAspNetActivity(rootActivity))
                 {
@@ -104,11 +108,11 @@ namespace Microsoft.AspNet.TelemetryCorrelation
 
         private static bool StartAspNetActivity(Activity activity)
         {
-            if (AspNetListener.IsEnabled(AspNetActivityName, activity, new { }))
+            if (AspNetListener.IsEnabled(AspNetActivityName, activity, EmptyPayload))
             {
                 if (AspNetListener.IsEnabled(AspNetActivityStartName))
                 {
-                    AspNetListener.StartActivity(activity, new { });
+                    AspNetListener.StartActivity(activity, EmptyPayload);
                 }
                 else
                 {


### PR DESCRIPTION
This is a new callback introduced in DiagnosticSource 4.6.0 that instrumentations should call when it read headers and set parents/context on the Activity but before Activity is started.

This serves two purposes
- tracing tool can support custom headers in the absence of default ones without creating a new Activity 
- tracing tool can make sampling decision earlier and prevent starting activity if it's sampled out