### PR TITLE
Create single activity for rewrite rule 

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -15,6 +15,13 @@ namespace Microsoft.AspNet.TelemetryCorrelation
     public class TelemetryCorrelationHttpModule : IHttpModule
     {
         private const string BeginCalledFlag = "Microsoft.AspNet.TelemetryCorrelation.BeginCalled";
+
+        // ServerVariable set only on rewritten HttpContext by URL Rewrite module.
+        private const string URLRewriteRewrittenRequest = "IIS_WasUrlRewritten";
+
+        // ServerVariable set on every request if URL module is registered in HttpModule pipeline.
+        private const string URLRewriteModuleVersion = "IIS_UrlRewriteModule";
+
         private static MethodInfo onStepMethodInfo = null;
 
         static TelemetryCorrelationHttpModule()
@@ -106,20 +113,21 @@ namespace Microsoft.AspNet.TelemetryCorrelation
             // BeginRequest has never been called
             if (!context.Items.Contains(BeginCalledFlag))
             {
-                // Exception happened before BeginRequest
-                if (context.Error != null)
+                // Rewrite: In case of rewrite, a new request context is created, called the child request, and it goes through the entire IIS/ASP.NET integrated pipeline.
+                // The child request can be mapped to any of the handlers configured in IIS, and it's execution is no different than it would be if it was received via the HTTP stack.
+                // The parent request jumps ahead in the pipeline to the end request notification, and waits for the child request to complete.
+                // When the child request completes, the parent request executes the end request notifications and completes itself.
+                // Do not create activity for parent request. Parent request has IIS_UrlRewriteModule ServerVariable with success response code.
+                // Child request contains an additional ServerVariable named - IIS_WasUrlRewritten.
+                // Track failed response activity: Different modules in the pipleline has ability to end the response. For example, authentication module could set HTTP 401 in OnBeginRequest and end the response.
+                if (context.Request.ServerVariables != null && context.Request.ServerVariables[URLRewriteRewrittenRequest] == null && context.Request.ServerVariables[URLRewriteModuleVersion] != null && context.Response.StatusCode == 200)
                 {
-                    // Activity has never been started
-                    ActivityHelper.CreateRootActivity(context, ParseHeaders);
+                    trackActivity = false;
                 }
                 else
                 {
-                    // Rewrite: In case of rewrite, a new request context is created, called the child request, and it goes through the entire IIS/ASP.NET integrated pipeline.
-                    // The child request can be mapped to any of the handlers configured in IIS, and it's execution is no different than it would be if it was received via the HTTP stack.
-                    // The parent request jumps ahead in the pipeline to the end request notification, and waits for the child request to complete.
-                    // When the child request completes, the parent request executes the end request notifications and completes itself.
-                    // Ignore creating root activity for parent request as control got transferred from rewrite module to EndRequest with no request flow.
-                    trackActivity = false;
+                    // Activity has never been started
+                    ActivityHelper.CreateRootActivity(context, ParseHeaders);
                 }
             }
 

--- a/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/TelemetryCorrelationHttpModule.cs
@@ -98,6 +98,7 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         private void Application_EndRequest(object sender, EventArgs e)
         {
             AspNetTelemetryCorrelationEventSource.Log.TraceCallback("Application_EndRequest");
+            bool trackActivity = true;
 
             var context = ((HttpApplication)sender).Context;
 
@@ -118,11 +119,14 @@ namespace Microsoft.AspNet.TelemetryCorrelation
                     // The parent request jumps ahead in the pipeline to the end request notification, and waits for the child request to complete.
                     // When the child request completes, the parent request executes the end request notifications and completes itself.
                     // Ignore creating root activity for parent request as control got transferred from rewrite module to EndRequest with no request flow.
-                    return;
+                    trackActivity = false;
                 }
             }
 
-            ActivityHelper.StopAspNetActivity(context.Items);
+            if (trackActivity)
+            {
+                ActivityHelper.StopAspNetActivity(context.Items);
+            }
         }
     }
 }


### PR DESCRIPTION
Addressing Issue #73 

## Changes
(Please provide a brief description of the changes here.)

Modified EndRequest in TelemetryCorrelationHttpModule to skip activity creation for rewrite generated parent request.

**Background Information**

Initial version of the TelemetryCorrelationHttpModule had this activity creation within Application_Error and later moved to EndRequest. 


https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/pull/1/files
https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/cc1592d241fee1df40442790fddf7779c787e838/src/Microsoft.AspNet.Diagnostics/DiagnosticsHttpModule.cs

![image](https://user-images.githubusercontent.com/9479006/83818527-70fce980-a67c-11ea-889f-10ba36d119bb.png)
 

https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/pull/2
https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/c0c6b8ce9e3f371c6012a2646e4a5f253fcaea41/src/Microsoft.AspNet.Diagnostics/DiagnosticsHttpModule.cs

Notes from PR

![image](https://user-images.githubusercontent.com/9479006/83818551-7f4b0580-a67c-11ea-8bea-99e572b48a90.png)
