### PR TITLE
Fix pipeline issue

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -54,6 +54,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>http://www.asp.net/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/e867e87e3a009223685b553dbb667b08bb9cab0c/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageTags>Diagnostics DiagnosticSource Correlation Activity ASP.NET</PackageTags>
     <RepositoryUrl>https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/</RepositoryUrl>

--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -51,10 +51,8 @@
     <Title>Microsoft Asp.Net telemetry correlation</Title>
     <Description>A module that instruments incoming request with System.Diagnostics.Activity and notifies listeners with DiagnosticsSource.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>http://www.asp.net/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/e867e87e3a009223685b553dbb667b08bb9cab0c/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageTags>Diagnostics DiagnosticSource Correlation Activity ASP.NET</PackageTags>
     <RepositoryUrl>https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/</RepositoryUrl>

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />


### PR DESCRIPTION
- Removed `PackageRequireLicenseAcceptance`, `PackageLicenseExpression` has license information
- Upgraded `Microsoft.Web.Xdt` to the latest version to remove vulnerability 