### PR TITLE
TelemetryCorrelationHttpModule: Exception Event

### DIFF
--- a/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.Tracing;
 #pragma warning disable SA1600 // Elements must be documented
 
@@ -16,6 +17,15 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         /// Instance of the PlatformEventSource class.
         /// </summary>
         public static readonly AspNetTelemetryCorrelationEventSource Log = new AspNetTelemetryCorrelationEventSource();
+
+        [NonEvent]
+        public void ActivityException(string id, string eventName, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+            {
+                ActivityException(id, eventName, ex.ToString());
+            }
+        }
 
         [Event(1, Message = "Callback='{0}'", Level = EventLevel.Verbose)]
         public void TraceCallback(string callback)
@@ -75,6 +85,12 @@ namespace Microsoft.AspNet.TelemetryCorrelation
         public void ActivityStackIsTooDeepDetails(string id, string name)
         {
             WriteEvent(10, id, name);
+        }
+
+        [Event(11, Message = "Activity exception, Id='{0}', Name='{1}': {2}", Level = EventLevel.Error)]
+        public void ActivityException(string id, string eventName, string ex)
+        {
+            WriteEvent(11, id, eventName, ex);
         }
     }
 }

--- a/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
+++ b/src/Microsoft.AspNet.TelemetryCorrelation/Microsoft.AspNet.TelemetryCorrelation.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Microsoft.AspNet.TelemetryCorrelation.ruleset" />

--- a/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
+++ b/test/Microsoft.AspNet.TelemetryCorrelation.Tests/Microsoft.AspNet.TelemetryCorrelation.Tests.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
My goal is to enable a `RecordException` option in [OpenTelemetry.Instrumentation.AspNet](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.AspNet) which will automatically call the [`RecordException`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs#L77) extension on `Activity` anytime an unhandled exception is fired in the hosting HttpApplication. To do that I need the `TelemetryCorrelationHttpModule` to write a `DiagnosticListener` ".Exception" event when [HttpApplication.Error](https://docs.microsoft.com/en-us/dotnet/api/system.web.httpapplication.error?view=netframework-4.8) is fired. 

/cc @cijothomas @reyang 